### PR TITLE
Fix transactionStatus Error to get variable statusCode #10

### DIFF
--- a/payment_duitku/models/payment_provider.py
+++ b/payment_duitku/models/payment_provider.py
@@ -83,7 +83,7 @@ class PaymentProvider(models.Model):
         endpoint = endpoint.strip("/")
         url = urls.url_join(self._duitku_get_api_url(), endpoint)
         try:
-            req = requests.post(url=url, data=data, headers=headers, allow_redirects=False)
+            req = requests.post(url=url, json=data, headers=headers, allow_redirects=False)
             response = req.json()
             if endpoint == 'transactionStatus':
                 if response['statusCode'] != '00':

--- a/payment_duitku/models/payment_provider.py
+++ b/payment_duitku/models/payment_provider.py
@@ -84,7 +84,12 @@ class PaymentProvider(models.Model):
         url = urls.url_join(self._duitku_get_api_url(), endpoint)
         try:
             req = requests.post(url=url, json=data, headers=headers, allow_redirects=False)
+            body = req.request.body
+            if isinstance(body, bytes):
+                body = body.decode()
             response = req.json()
+            _logger.info('Duitku request for {endpoint} \n {request} \n {body}'.format(endpoint=endpoint,request=pprint.pformat(dict(req.request.headers)),body=body))
+            _logger.info('Duitku response for {endpoint} \n {response}'.format(endpoint=endpoint,response=pprint.pformat(response)))
             if endpoint == 'transactionStatus':
                 if response['statusCode'] != '00':
                     raise ValidationError(_("Payment has not been successfully paid but a callback is triggered."

--- a/payment_duitku/models/payment_transaction.py
+++ b/payment_duitku/models/payment_transaction.py
@@ -175,7 +175,7 @@ class PaymentTransaction(models.Model):
 
         payload, headers = self._duitku_prepare_payment_request_payload(processing_values)
         _logger.info("sending '/createInvoice' request for link creation:\n%s", pprint.pformat(payload))
-        payment_data = self.provider_id._duitku_make_request('/createInvoice',data=json.dumps(payload),headers=headers)
+        payment_data = self.provider_id._duitku_make_request('/createInvoice',data=payload,headers=headers)
 
         # if the merchantOrderId already exists in Duitku and you try to pay again, the createInvoice return
         # ("MerchantOrderId":"Bill already paid. (Parameter \u0027MerchantOrderId\u0027)")


### PR DESCRIPTION
Pada Issue #10 terdapat kendala kendala pada Plugin Odoo khususnya untuk Odoo versi 16.0, dimana saat callback dikirim dari Duitku, tetapi status order pada Odoo tidak beurbah menjadi Paid.

Pada docker muncul error 
```
    if response['statusCode'] != '00':
KeyError: 'statusCode'
```

setelah di check lebih lanjut, callback sudah dapat diterima tetapi pada saat mengirimkan request ke API Duitku
`req = requests.post(url=url, data=data, headers=headers, allow_redirects=False)`
bukannya menggunakan tipe body **JSON**, disini malah digunakan tipe body **data** (dictionary atau form-encoded) yang mana tidak sesuai dengan API Duitku, walaupun pada header telah menggunakan `'Content-Type': 'application/json'` sekalipun.

Akibatnya pada saat callback diterima, dan dilakukan check transaksi dengan API `/transactionStatus`, akan mendapatkan response error dan `statusCode `tidak diterima. Sedangkan pada hit API `/createInvoice` tidak ada kendala, karena pada request telah ditambahkan fungsi `json.dumps()` yang sebenarnya bukan best practice untuk kondisi ini.

Pada Pull Request ini membenahi tipe data saat request menjadi **JSON**, dan menghapus `json.dumps()`, serta menambahkan log saat request ke API Duitku